### PR TITLE
Fixing pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name = 'AlphaTwirl',
@@ -7,5 +7,5 @@ setup(
     author = 'Tai Sakuma',
     author_email = 'tai.sakuma@gmail.com',
     url = 'https://github.com/TaiSakuma/AlphaTwirl',
-    packages = ['alphatwirl'],
+    packages = find_packages(exclude=['docs', 'images', 'tests']),
 )


### PR DESCRIPTION
Currently, only `alphatwirl/__init__.py` is installed without any of the sub-packages.
This PR fixes that.

```bash
pip install --process-dependency-links -U --user git+git://github.com/TaiSakuma/AlphaTwirl
ll ~/.local/lib/python2.7/site-packages/alphatwirl/
total 8
-rw-rw-r-- 1 vagrant vagrant 1052 May 25 15:43 __init__.py
-rw-rw-r-- 1 vagrant vagrant 1105 May 25 15:43 __init__.pyc
python -c 'import alphatwirl'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/vagrant/.local/lib/python2.7/site-packages/alphatwirl/__init__.py", line 12, in <module>
    from . import binning
ImportError: cannot import name binning
```
versus
```bash
pip install --process-dependency-links -U --user git+git://github.com/kreczko/AlphaTwirl
ll ~/.local/lib/python2.7/site-packages/alphatwirl/
total 60
-rw-rw-r-- 1 vagrant vagrant 1052 May 25 15:44 __init__.py
-rw-rw-r-- 1 vagrant vagrant 1105 May 25 15:44 __init__.pyc
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 binning
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 cmsedm
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 collector
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 concurrently
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 configure
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 delphes
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 heppyresult
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 loop
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 misc
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 progressbar
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 roottree
drwxrwxr-x 4 vagrant vagrant 4096 May 25 15:44 selection
drwxrwxr-x 2 vagrant vagrant 4096 May 25 15:44 summary
[vagrant@localhost vagrant]$ python -c 'import alphatwirl'
```
